### PR TITLE
removed joda time dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,6 @@ dependencies {
         exclude group: "org.slf4j", module: "slf4j-log4j12"
     }
 
-    compileOnly "joda-time:joda-time:2.9.2"
-
     compileOnly "org.apache.spark:spark-core_$versions.scala:$versions.spark",
                 "org.apache.spark:spark-sql_$versions.scala:$versions.spark"
 

--- a/src/intTest/scala/RelationSuite.scala
+++ b/src/intTest/scala/RelationSuite.scala
@@ -1,5 +1,6 @@
 import java.net.URI
 import java.sql.Timestamp
+import java.time.Instant
 
 import com.emc.ecs.spark.sql.sources.s3._
 import com.emc.ecs.spark.util.ExampleData._
@@ -79,6 +80,14 @@ class RelationSuite extends WordSpec with Matchers
       }
       "push-down indexed columns" ignore {
         // TODO verify predicate push-down
+      }
+
+      "support querying by date" in sparkContext { implicit ctx =>
+        import ctx.spark.implicits._
+        val date = Timestamp.from(Instant.EPOCH)
+        val df = bucket(withSystemMetadata = true).where($"datetime1" > date)
+        val rows = df.collect()
+        rows.length should be (exampleData.length)
       }
     }
 

--- a/src/main/scala/com/emc/ecs/spark/sql/sources/s3/utils.scala
+++ b/src/main/scala/com/emc/ecs/spark/sql/sources/s3/utils.scala
@@ -2,8 +2,8 @@ package com.emc.ecs.spark.sql.sources.s3
 
 import java.net.URI
 import java.sql.Timestamp
+import java.time.Instant
 
-import org.joda.time.Instant
 import com.emc.`object`.s3.{S3Client, S3Config}
 import com.emc.`object`.s3.bean.{MetadataSearchDatatype, MetadataSearchKey}
 import com.emc.`object`.s3.jersey.S3JerseyClient
@@ -100,7 +100,7 @@ private[spark] object QueryGenerator {
     def format(argument: Any): String = argument match {
       case s:String => s"'$s'"
       case i:Number => i.toString
-      case t:Timestamp => new Instant(t.getTime).toString
+      case t:Timestamp => t.toInstant().toString
       case a:Any => s"'$a'"
     }
   }


### PR DESCRIPTION
- removed joda time dependency
- added test for query-by-date

the test demonstrates that a good search request is generated (see the `query=` parameter):
```
GET /test-f2f6a31b-be0c-41be-8b75-c9fea61f1c06?attributes=LastModified%2COwner%2CSize%2CCreateTime%2CContentType%2CEtag%2CExpiration%2CContentEncoding%2CExpires%2CRetention%2CNamespace%2CObjectName&query=datetime1%3E1970-01-01T00%3A00%3A00Z
```